### PR TITLE
Fix failing tests

### DIFF
--- a/tests/Adapter/TolerantParser/TolerantClassReplacerTest.php
+++ b/tests/Adapter/TolerantParser/TolerantClassReplacerTest.php
@@ -86,8 +86,8 @@ class TolerantClassReplacerTest extends TestCase
                 'Acme\\Definee\\Barfoo',
                 <<<'EOT'
                     namespace Acme;
-                    use Acme\Definee\Barfoo;
 
+                    use Acme\Definee\Barfoo;
 
                     class Hello
                     {
@@ -160,8 +160,8 @@ class TolerantClassReplacerTest extends TestCase
                 'Example',
                 'Phpactor\ClassMover\Example',
                 <<<'EOT'
-
                     use Phpactor\ClassMover\Example;
+
                     class ClassOne
                     {
                         public function build(): Example


### PR DESCRIPTION
It seems like there was a problem in tests with the formatting of expected class.

Tests were failing on PHP 8.0.6 and PHPUnit 9.5.10.